### PR TITLE
clean up and remove extra, unnecessary piece of the issue template

### DIFF
--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -11,21 +11,6 @@ things up, how to use Docker.
 If you are reporting about security vulnerability in the site or about some malicious image that
 should be taken down ASAP then please report it via email to security@docker.com. 
 
-## Issues related to running a container in a user's local environment or user's on-prem/cloud based cluster.
-- If you are a community user using our Docker Engine product, Please go to https://forums.docker.com/ and verify if other members in the community have run into this issue, or post an issue back to the community.
-- If you are a user with a subscription to Docker, you can go to https://hub.docker.com/support/contact/ and create a support ticket.
-
-Please, verify if similar issue is already open by someone else before creating new one. You can
-thumbs up an existing issue to express your concern. 
-
--->
-
-
-<!--
-
-Great, you are in the right place! Do one of these common issues describe the problem you are experiencing?
-
-
 ## Account Activation Issues
 Please go to https://hub.docker.com/support/contact/ and open a ticket so our support team can
 activate your account. 
@@ -37,56 +22,21 @@ password for your Docker Hub account.
 ## Deleting User Accounts and Organization Accounts
 Please see https://docs.docker.com/docker-hub/deactivate-account/ for next steps.
 
+## Other Community Resources
+The [Docker Forums](https://forums.docker.com/) and [Docker Paid Support](https://hub.docker.com/support/contact/)
+are other helpful resources that are provided to help answer your questions!
+
 -->
 
 
-
-## Problem description
-
-
-## `docker info` output
 <!--
-This is only necessary if the problem includes using Docker Desktop or Docker Engine in order 
-to replicate the issue you are seeing
--->
-Docker Info:
-```yaml
 
-```
+Great, you are in the right place! Please provide as much detail as you think is necessary to help 
+us help you! 
 
+Please, verify if a similar issue is already open by someone else before creating new one. You can
+thumbs up an existing issue to express your concern. 
 
-## Debug Information
-**Browser name and version**:
-
-
-<!-- if applicable, where did you get your error? -->
-**URL**:
-
-
-<!-- please include your timezone -->
-**Timetamp or time range**: 
-
-
-<!--  address of the machine which encountered the error -->
-**Public IP**: 
-
-
-**Hub Username**:
-
-
-## Error messages (on screen or in browser console)
-
-
-
-## Screenshots of the issue (if applicable)
-<!--
-Please redact or blur any private information!
 -->
 
 
-
-
-# Task List
-- [ ] This is **NOT** a security issue
-- [ ] I do **NOT** have a Docker subscription
-- [ ] I have looked through other issues and they do **NOT** apply to me


### PR DESCRIPTION
We have found that since introducing the new issue template, it is rarely followed. In addition, the types of issues which are opened in this repository vary wildly. It does not make sense to attempt to encapsulate all of this in a single template. I am recommending we provide the included list of resources as a comment and leave it up to the community member's discretion to include the necessary details so that we can help them.